### PR TITLE
Add validation to prevent nil rules

### DIFF
--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -68,6 +68,7 @@ module IceCube
 
     # Add a recurrence rule to the schedule
     def add_recurrence_rule(rule)
+      fail ArgumentError, 'Rule cannot be nil' if rule.nil?
       @all_recurrence_rules << rule unless @all_recurrence_rules.include?(rule)
     end
     alias :rrule :add_recurrence_rule
@@ -80,6 +81,7 @@ module IceCube
 
     # Add an exception rule to the schedule
     def add_exception_rule(rule)
+      fail ArgumentError, 'Rule cannot be nil' if rule.nil?
       @all_exception_rules << rule unless @all_exception_rules.include?(rule)
     end
     alias :exrule :add_exception_rule

--- a/spec/examples/schedule_spec.rb
+++ b/spec/examples/schedule_spec.rb
@@ -563,6 +563,24 @@ describe IceCube::Schedule do
 
   end
 
+  describe :add_exception_rule do
+    it 'should throw argument error for nil rule' do
+      schedule = IceCube::Schedule.new(Time.now)
+      lambda do
+        schedule.add_exception_rule(nil)
+      end.should raise_error ArgumentError, 'Rule cannot be nil'
+    end
+  end
+
+  describe :add_recurrence_rule do
+    it 'should throw argument error for nil rule' do
+      schedule = IceCube::Schedule.new(Time.now)
+      lambda do
+        schedule.add_recurrence_rule(nil)
+      end.should raise_error ArgumentError, 'Rule cannot be nil'
+    end
+  end
+
   describe :remove_recurrence_rule do
 
     it 'should be able to one rule based on the comparator' do


### PR DESCRIPTION
Stumbled on this by accident but the `add_recurrence_rule` / `add_exception_rule` methods allow nil which later leads to errors like below when invoking various methods like `occurrences_between`:

`NoMethodError: undefined method`reset' for nil:NilClass`

Simple example:

``` ruby
s = IceCube::Schedule.new(Time.now)
s.add_recurrence_rule(Random.new)
s.occurrences_between(Time.now, Time.now + 36000)
```

I was also thinking it could be a good idea to add a `is_a?(Rule)` validation as well since there are quite a few methods an object has to respond to in order to work as a Rule but I just left it at a simple nil check for now.
