### PR TITLE
Correctly export exrules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix for weekly interval results when requesting `occurrences_between` on a narrow range ([#487](https://github.com/seejohnrun/ice_cube/pull/487)) by [@jakebrady5](https://github.com/jakebrady5)
 - When using a rule with hour_of_day validations, and asking for occurrences on the day that DST skips forward, valid occurrences would be missed. ([#464](https://github.com/seejohnrun/ice_cube/pull/464)) by [@jakebrady5](https://github.com/jakebrady5)
+- Include `exrules` when exporting a schedule to YAML, JSON or a Hash. ([#519](https://github.com/ice-cube-ruby/ice_cube/pull/519)) by [@pacso](https://github.com/pacso)
 
 ## [0.16.4] - 2021-10-21
 ### Added

--- a/lib/ice_cube/parsers/hash_parser.rb
+++ b/lib/ice_cube/parsers/hash_parser.rb
@@ -60,7 +60,6 @@ module IceCube
 
     def apply_exrules(schedule, data)
       return unless data[:exrules]
-      warn "IceCube: :exrules is deprecated, and will be removed in a future release. at: #{caller(1..1).first}"
       data[:exrules].each do |h|
         rrule = h.is_a?(IceCube::Rule) ? h : IceCube::Rule.from_hash(h)
 

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -358,9 +358,7 @@ module IceCube
       data[:start_date] = data[:start_time] if IceCube.compatibility <= 11
       data[:end_time] = TimeUtil.serialize_time(end_time) if end_time
       data[:rrules] = recurrence_rules.map(&:to_hash)
-      if IceCube.compatibility <= 11 && exception_rules.any?
-        data[:exrules] = exception_rules.map(&:to_hash)
-      end
+      data[:exrules] = exception_rules.map(&:to_hash) if exception_rules.any?
       data[:rtimes] = recurrence_times.map do |rt|
         TimeUtil.serialize_time(rt)
       end

--- a/spec/examples/to_yaml_spec.rb
+++ b/spec/examples/to_yaml_spec.rb
@@ -132,6 +132,18 @@ module IceCube
       expect(schedule.first(10).map { |r| r.to_s }).to eq(schedule2.first(10).map { |r| r.to_s })
     end
 
+    it "should be able to make a round-trip to YAML whilst preserving exception rules" do
+      original_schedule = Schedule.new(Time.now)
+      original_schedule.add_recurrence_rule Rule.daily.day(:monday, :wednesday)
+      original_schedule.add_exception_rule Rule.daily.day(:wednesday)
+
+      yaml_string = original_schedule.to_yaml
+      returned_schedule = Schedule.from_yaml(yaml_string)
+
+      # compare without usecs
+      expect(returned_schedule.first(10).map { |r| r.to_s }).to eq(original_schedule.first(10).map { |r| r.to_s })
+    end
+
     it "should have a to_yaml representation of a rule that does not contain ruby objects" do
       rule = Rule.daily.day_of_week(monday: [1, -1]).month_of_year(:april)
       expect(rule.to_yaml.include?("object")).to be_falsey


### PR DESCRIPTION
Fixes #518 

- Exports exrules when `to_hash` is called, regardless of gem version
- Also fixes `to_yaml` and `to_json` since they both call `to_hash`
- Removes deprecation warning on use of `exrules`