### PR TITLE
Introduce occurrences_between_enumerator method

### DIFF
--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -207,6 +207,10 @@ module IceCube
       enumerate_occurrences(from, nil, options)
     end
 
+    def occurrences_between_enumerator(begin_time, closing_time, options = {})
+      enumerate_occurrences(begin_time, closing_time, options)
+    end
+
     # Occurrences between two times
     def occurrences_between(begin_time, closing_time, options = {})
       enumerate_occurrences(begin_time, closing_time, options).to_a

--- a/spec/examples/schedule_spec.rb
+++ b/spec/examples/schedule_spec.rb
@@ -318,6 +318,19 @@ describe IceCube::Schedule do
     end
   end
 
+  describe :occurrences_between_enumerator do
+    it do
+      schedule = IceCube::Schedule.new(Time.new(2021, 1, 1))
+      schedule.add_recurrence_rule(IceCube::Rule.from_ical("FREQ=MONTHLY;BYMONTHDAY=-1"))
+
+      start = Time.new(2022, 1, 1)
+      finish = start + 365 * IceCube::ONE_DAY
+      dates = schedule.occurrences_between_enumerator(start, finish).lazy.map(&:to_date).first(2)
+
+      expect(dates).to eq [Date.new(2022, 1, 31), Date.new(2022, 2, 28)]
+    end
+  end
+
   describe :all_occurrences do
     it "has end times for each occurrence" do
       schedule = IceCube::Schedule.new(Time.now, duration: IceCube::ONE_HOUR)


### PR DESCRIPTION
This PR adds new method `occurrences_between_enumerator` as well as enumerators (`remaining_occurrences_enumerator`, `all_occurrences_enumerator`) are exists

This method allows using lazy for fetch occurrences between start/finish dates, as it used in test example. 