### PR TITLE
fix(i18n): Delegate arguements properly for Ruby 3

### DIFF
--- a/lib/ice_cube/i18n.rb
+++ b/lib/ice_cube/i18n.rb
@@ -4,12 +4,12 @@ module IceCube
   module I18n
     LOCALES_PATH = File.expand_path(File.join("..", "..", "..", "config", "locales"), __FILE__)
 
-    def self.t(*args, **kwargs)
-      backend.t(*args, **kwargs)
+    def self.t(*args, **kwargs, &block)
+      backend.t(*args, **kwargs, &block)
     end
 
-    def self.l(*args, **kwargs)
-      backend.l(*args, **kwargs)
+    def self.l(*args, **kwargs, &block)
+      backend.l(*args, **kwargs, &block)
     end
 
     def self.backend


### PR DESCRIPTION
### Why this was needed
In Ruby 3, we need to explicitly handle each type of arg when delegating to another method. Positional args, kwargs, and blocks all separately. See "Handling Argument Delegation in https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Alternatively, seeing that Ruby 2.7 is EOL at the end of this month I think it is time we can stop supporting Ruby 2.6. With that, we can use the new delegation syntax (...) introduced in Ruby 2.7.

### How I did it
- Added explicit `&block` to parameter list to delegate methods