### PR TITLE
fix I18n.load_path injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Removed use of `delegate` method added in [66f1d797](https://github.com/ice-cube-ruby/ice_cube/commit/66f1d797092734563bfabd2132c024c7d087f683) , reverting to previous implementation. ([#522](https://github.com/ice-cube-ruby/ice_cube/pull/522))  by [@pacso](https://github.com/pacso)
 - Updated supported versions of Ruby and Rails and fixed standardrb lint issues. ([#552](https://github.com/ice-cube-ruby/ice_cube/pull/552)) by [@pacso](https://github.com/pacso)
+- Fixed `I18n.load_path` injection ([#546](https://github.com/ice-cube-ruby/ice_cube/pull/546)) by [@glaszig](https://github.com/glaszig)
 
 ### Fixed
 - Fix for weekly interval results when requesting `occurrences_between` on a narrow range ([#487](https://github.com/seejohnrun/ice_cube/pull/487)) by [@jakebrady5](https://github.com/jakebrady5)

--- a/lib/ice_cube.rb
+++ b/lib/ice_cube.rb
@@ -6,7 +6,8 @@ module IceCube
 
   autoload :TimeUtil, "ice_cube/time_util"
   autoload :FlexibleHash, "ice_cube/flexible_hash"
-  autoload :I18n, "ice_cube/i18n"
+
+  require "ice_cube/i18n"
 
   autoload :Rule, "ice_cube/rule"
   autoload :Schedule, "ice_cube/schedule"

--- a/lib/ice_cube/i18n.rb
+++ b/lib/ice_cube/i18n.rb
@@ -3,6 +3,7 @@ require "ice_cube/null_i18n"
 module IceCube
   LOCALES_PATH = File.expand_path(File.join("..", "..", "config", "locales"), __dir__)
 
+  # rubocop:disable Naming/ConstantName
   I18n = begin
     require "i18n"
     ::I18n.load_path += Dir[File.join(LOCALES_PATH, "*.yml")]
@@ -10,4 +11,5 @@ module IceCube
   rescue LoadError
     NullI18n
   end
+  # rubocop:enable Naming/ConstantName
 end

--- a/lib/ice_cube/i18n.rb
+++ b/lib/ice_cube/i18n.rb
@@ -1,7 +1,7 @@
 require "ice_cube/null_i18n"
 
 module IceCube
-  LOCALES_PATH = File.expand_path(File.join("..", "..", "..", "config", "locales"), __FILE__)
+  LOCALES_PATH = File.expand_path(File.join("..", "..", "config", "locales"), __dir__)
 
   I18n = begin
     require "i18n"

--- a/lib/ice_cube/i18n.rb
+++ b/lib/ice_cube/i18n.rb
@@ -1,26 +1,13 @@
 require "ice_cube/null_i18n"
 
 module IceCube
-  module I18n
-    LOCALES_PATH = File.expand_path(File.join("..", "..", "..", "config", "locales"), __FILE__)
+  LOCALES_PATH = File.expand_path(File.join("..", "..", "..", "config", "locales"), __FILE__)
 
-    def self.t(*args, **kwargs)
-      backend.t(*args, **kwargs)
-    end
-
-    def self.l(*args, **kwargs)
-      backend.l(*args, **kwargs)
-    end
-
-    def self.backend
-      @backend ||= detect_backend!
-    end
-
-    def self.detect_backend!
-      ::I18n.load_path += Dir[File.join(LOCALES_PATH, "*.yml")]
-      ::I18n
-    rescue NameError
-      NullI18n
-    end
+  I18n = begin
+    require "i18n"
+    ::I18n.load_path += Dir[File.join(LOCALES_PATH, "*.yml")]
+    ::I18n
+  rescue LoadError
+    NullI18n
   end
 end

--- a/spec/examples/to_s_en_spec.rb
+++ b/spec/examples/to_s_en_spec.rb
@@ -212,7 +212,7 @@ describe IceCube::Schedule, "to_s" do
     before(:each) { I18n.locale = :en }
 
     it "uses I18n" do
-      expect(IceCube::I18n.backend).to eq(I18n)
+      expect(IceCube::I18n).to eq ::I18n
     end
 
     it_behaves_like "to_s in English"


### PR DESCRIPTION
ice_cube would inject its locale files at the end of `I18n.load_path` due to its `IceCube::I18n` module being `autoload`ed and thereby overwrite any customisation the user may have made in other locale files earlier in the load path.

i fix this by injecting ice cube locales at gem load time so that the user has a chance to modify locale keys later.

this also eliminates a bunch of delegation having a custom I18n module; `IceCube::I18n` is just the same as ::I18n if the i18n gem is available.

resolves #489, #432, #431