### PR TITLE
weekly rule DST issue

### DIFF
--- a/spec/examples/fixed_value_spec.rb
+++ b/spec/examples/fixed_value_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe IceCube::Validations::HourOfDay::Validation do
+
+  describe :validate do
+    let(:timezone) { "Africa/Cairo" }
+    let(:time) { "2024-05-03 00:20:00" }
+    let(:time_in_zone) { ActiveSupport::TimeZone[timezone].parse(time) }
+    let(:start_time) { ActiveSupport::TimeZone[timezone].parse("2024-04-26 01:20:00") }
+
+    let(:validation) { IceCube::Validations::HourOfDay::Validation.new(nil) }
+
+    it "returns the correct offset for the same hour" do
+      expect(validation.validate(time_in_zone, start_time)).to eq 1
+    end
+  end
+end

--- a/spec/examples/schedule_spec.rb
+++ b/spec/examples/schedule_spec.rb
@@ -390,6 +390,35 @@ describe IceCube::Schedule do
       expect(next_hours).to eq [Time.utc(2014, 1, 2, 0o0, 34, 56),
         Time.utc(2014, 1, 2, 0o1, 34, 56)]
     end
+
+    context "Cairo timezone" do
+      let(:schedule) do
+        IceCube::Schedule.from_yaml("---\n:start_time:\n  :time: 2022-05-05 22:20:00.000000000 Z\n  :zone: Africa/Cairo\n:end_time:\n  :time: 2022-05-06 21:40:00.000000000 Z\n  :zone: Africa/Cairo\n:rrules:\n- :validations:\n    :day:\n    - 5\n  :rule_type: IceCube::WeeklyRule\n  :interval: 1\n  :week_start: 1\n:rtimes: []\n:extimes: []\n")
+      end
+      
+      it "has the correct start time" do
+        expect(schedule.start_time.iso8601).to eq("2022-05-06T00:20:00+02:00")
+      end
+
+      it "calculates the corret occurrences from 2024-04-24" do
+        ref_time = Time.utc(2024, 4, 24, 12, 0, 0)
+        occurrences = schedule.next_occurrences(3, ref_time)
+        expect(occurrences.map(&:iso8601)).to eq([
+          "2024-04-26T01:20:00+03:00",
+          "2024-05-03T00:20:00+03:00",
+          "2024-05-10T00:20:00+03:00"
+        ])
+      end
+
+      it "calculates the corret occurrences from 2024-04-21" do
+        occurrences = schedule.next_occurrences(3, Time.utc(2024, 4, 21, 12, 0, 0))
+        expect(occurrences.map(&:iso8601)).to eq([
+          "2024-04-26T01:20:00+03:00",
+          "2024-05-03T00:20:00+03:00",
+          "2024-05-10T00:20:00+03:00"
+        ])
+      end
+    end
   end
 
   describe :next_occurrence do

--- a/spec/examples/time_util_spec.rb
+++ b/spec/examples/time_util_spec.rb
@@ -118,5 +118,21 @@ module IceCube
         end
       end
     end
+
+    describe :dst_change do
+      let(:timezone) { "Africa/Cairo" }
+      let(:time) { "2024-04-26 00:20:00" }
+      let(:time_in_zone) { ActiveSupport::TimeZone[timezone].parse(time) }
+
+      subject { TimeUtil.dst_change(time_in_zone) }
+
+      it { is_expected.to eql(1) }
+
+      context "when time is not on a DST change" do
+        let(:time) { "2024-04-25 00:20:00" }
+
+        it { is_expected.to be_nil }
+      end
+    end
   end
 end

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -390,5 +390,40 @@ module IceCube
         end
       end
     end
+
+    context "when start time is within a timezone shift in Africa/Cairo timezone", system_time_zone: "UTC" do
+      let(:cairo_tz) { ActiveSupport::TimeZone["Africa/Cairo"] }
+      let(:utc_tz) { ActiveSupport::TimeZone["UTC"] }
+      let(:start_time) { cairo_tz.parse("2022-05-22 00:20:00") }
+      let(:rule) { Rule.weekly(1, :monday).day(:friday) }
+
+      it "parses the start time correctly" do
+        expect(start_time.iso8601).to eq("2022-05-22T00:20:00+02:00")
+      end
+
+      it "calculates the correct time from 2024-04-24 12:00:00 UTC" do
+        expect(rule.next_time(utc_tz.parse("2024-04-24 12:00:00"), start_time, nil).iso8601).to eq("2024-04-26T01:20:00+03:00")
+      end
+
+      it "calculates the correct time from 2024-04-26 00:20:01 Africa/Cairo" do
+        expect(rule.next_time(cairo_tz.parse("2024-04-26 00:20:01"), start_time, nil).iso8601).to eq("2024-05-03T00:20:00+03:00")
+      end
+    end
+
+    describe :realign do
+      let(:cairo_tz) { ActiveSupport::TimeZone["Africa/Cairo"] }
+      let(:utc_tz) { ActiveSupport::TimeZone["UTC"] }
+      let(:start_time) { cairo_tz.parse("2022-05-22 00:20:00") }
+      let(:time) { utc_tz.parse("2024-04-24 12:00:00") }
+      let(:rule) { Rule.weekly(1, :monday).day(:friday) }
+
+      subject { rule.realign(time, start_time)}
+
+      it { puts cairo_tz.parse("2024-04-26T00:20:00") }
+
+      it "realigns the start time to the correct time" do
+        expect(subject.iso8601).to eq("2024-04-26T01:20:00+03:00")
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi,

I added some specs for the following edge case where the calculation of the next occurrences returns faulty values.
The base of this issue is `IceCube::WeeklyRule.realign` when an occurrence happens within a DST time switch. For example on `26th April 2024 00:00` -> `01:00`. Realign will change the start_time of e.g. `22th May 2022 00:20` to `26th April 2024 01:20` and then the starting hour is wrong. The result is occurrences with the time `01:20` instead of `00:20`. 

It would be great if someone could guide me to the place where this can get fixed. 

Thanks
Lars