### PR TITLE
Add backwards compatibility to Ruby 2.6

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         rails: ['6.1', '7.0', '7.1']
-        ruby: ['3.1', '3.2', '3.3']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
     runs-on: ubuntu-latest
     env:
       RAILS_VERSION: ${{ matrix.rails }}

--- a/lib/ice_cube/input_alignment.rb
+++ b/lib/ice_cube/input_alignment.rb
@@ -8,16 +8,16 @@ module IceCube
 
     attr_reader :rule, :value, :rule_part
 
-    def verify(freq, options = {}, &)
+    def verify(freq, options = {}, &block)
       @rule.validations[:interval] or return
 
       case @rule
       when DailyRule
-        verify_wday_alignment(freq, &)
+        verify_wday_alignment(freq, &block)
       when MonthlyRule
-        verify_month_alignment(freq, &)
+        verify_month_alignment(freq, &block)
       else
-        verify_freq_alignment(freq, &)
+        verify_freq_alignment(freq, &block)
       end
     end
 

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -160,8 +160,8 @@ module IceCube
     end
 
     # Iterate forever
-    def each_occurrence(&)
-      enumerate_occurrences(start_time, &).to_a
+    def each_occurrence(&block)
+      enumerate_occurrences(start_time, &block).to_a
       self
     end
 


### PR DESCRIPTION
This removes use of the "anonymous block argument" feature which is only supported in Ruby 3.1+ so that the library stays backwards compatible to earlier ruby versions.