### PR TITLE
Add rails 7.2 and 8.0 to github action tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
       - lint
     strategy:
       matrix:
-        rails: ['6.1', '7.0', '7.1']
+        rails: ['6.1', '7.0', '7.1', '7.2', '8.0']
         ruby: ['3.1', '3.2', '3.3']
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Rails 7.2 and 8.0 have been out for a while now.  Lets add them to the test matrix.